### PR TITLE
pfmove and pfnew improvements

### DIFF
--- a/PfamScripts/svn/pfnew.pl
+++ b/PfamScripts/svn/pfnew.pl
@@ -237,6 +237,9 @@ unless ( Bio::Pfam::PfamQC::passesAllFormatChecks( $newFamObj, $family, undef, u
 open( M, ">.default" . $$ . "pfnew" )
   or die "Could not open .default" . $$ . "pfnew:[$!]\n";
 print M $newFamObj->DESC->ID . " deposited\n";
+if ($message) {
+  print M $message;
+}
 close M;
 $client->addPFNEWLog();
 


### PR DESCRIPTION
for pfmove, check that the new name is not already at use at the start.
for pfnew, pass on the provided commit message instead of ignoring it.